### PR TITLE
refactor: reset line when radiation setting changes

### DIFF
--- a/src/components/lab/EmittedLine.js
+++ b/src/components/lab/EmittedLine.js
@@ -33,12 +33,21 @@ class EmittedLine extends Component {
     t: 0,
   };
 
-  componentDidUpdate({ isPaused: prevIsPaused }) {
-    const { isPaused } = this.props;
+  componentDidUpdate({
+    isPaused: prevIsPaused,
+    showEmittedLines: prevShowEmittedLines,
+  }) {
+    const { isPaused, showEmittedLines } = this.props;
     if (isPaused !== prevIsPaused && isPaused) {
       clearInterval(this.emittedLineInterval);
     } else if (isPaused !== prevIsPaused && !isPaused) {
       this.beginLineInterval();
+    }
+
+    // reset line on show/hide emitted lines
+    if (prevShowEmittedLines !== showEmittedLines) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ points: [0, 0] });
     }
   }
 

--- a/src/components/lab/EmittedLine.js
+++ b/src/components/lab/EmittedLine.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import _ from 'lodash';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Line } from 'react-konva';
@@ -33,10 +34,10 @@ class EmittedLine extends Component {
     t: 0,
   };
 
-  componentDidUpdate({
-    isPaused: prevIsPaused,
-    showEmittedLines: prevShowEmittedLines,
-  }) {
+  componentDidUpdate(
+    { isPaused: prevIsPaused, showEmittedLines: prevShowEmittedLines },
+    { points: prevPoints },
+  ) {
     const { isPaused, showEmittedLines } = this.props;
     if (isPaused !== prevIsPaused && isPaused) {
       clearInterval(this.emittedLineInterval);
@@ -45,7 +46,10 @@ class EmittedLine extends Component {
     }
 
     // reset line on show/hide emitted lines
-    if (prevShowEmittedLines !== showEmittedLines) {
+    if (
+      prevShowEmittedLines !== showEmittedLines &&
+      !_.isEqual(prevPoints, [0, 0])
+    ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ points: [0, 0] });
     }


### PR DESCRIPTION
Each time Radiation is on, the lines go upward, even if the simulation is running. Previously, turning on the Radiation during simulation would display the lines already fully drawn.

close #51 